### PR TITLE
feat: add a run command, and small libvirt scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vixos.egg-info
 venv/
 build/
+__pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+libvirt-python

--- a/vixos/libvirt_utils.py
+++ b/vixos/libvirt_utils.py
@@ -1,0 +1,15 @@
+import libvirt
+from contextlib import contextmanager
+from typing import Any
+
+
+@contextmanager
+def libvirt_connection(uri: str) -> Any:
+    conn = libvirt.open(uri)
+    if not conn:
+        raise RuntimeError(f"Failed to open connection to {uri}")
+
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/vixos/main.py
+++ b/vixos/main.py
@@ -1,8 +1,30 @@
 import argparse
+from .libvirt_utils import libvirt_connection
+
+
+def run(args):
+    print(f"OK, running {args.package}...")
+
+    with libvirt_connection("qemu:///system") as conn:
+        print(conn.getCapabilities())
+
 
 def main():
-    parser = argparse.ArgumentParser(description="VixOS is a secure application launcher.")
+    parser = argparse.ArgumentParser(
+        description="VixOS is a secure application launcher."
+    )
+
+    subparsers = parser.add_subparsers(title="subcommands", required=True)
+    run_parser = subparsers.add_parser("run", help="Run a nixpkgs program")
+    run_parser.set_defaults(func=run)
+    run_parser.add_argument(
+        "package",
+        help="Name of the nixpkgs package to run.",
+    )
+
     args = parser.parse_args()
+    args.func(args)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This adds a run command, that can be used like this:

```
$ python3 -m vixos.main run firefox                                                                                                                                                                                                                     python310Packages.libvirt
OK, running firefox...
...
```

Currently the command just dumps libvirt capabilities, but in the future it will obviously become more powerful (more than you can possibly imagine).