### PR TITLE
Migrate from qxl to virtio

### DIFF
--- a/vixos/template_xml.py
+++ b/vixos/template_xml.py
@@ -69,7 +69,7 @@ gui_devices = """
       <target type='virtio' name='com.redhat.spice.0'/>
     </channel>
     <video>
-      <model type='qxl' primary='yes'/>
+      <model type='virtio' heads='1' primary='yes'/>
     </video>
 """
 


### PR DESCRIPTION
Otherwise I get hangs like this:
```
[   13.129503] input: spice vdagent tablet as /devices/virtual/input/input6
[   42.551698] qxl 0000:00:02.0: object_init failed for (16388096, 0x00000001)
[   42.551708] [drm:qxl_alloc_bo_reserved [qxl]] *ERROR* failed to allocate VRAM BO
[   65.591768] qxl 0000:00:02.0: object_init failed for (16388096, 0x00000001)
[   65.591780] [drm:qxl_alloc_bo_reserved [qxl]] *ERROR* failed to allocate VRAM BO
[   99.383788] qxl 0000:00:02.0: object_init failed for (16388096, 0x00000001)
[   99.383800] [drm:qxl_alloc_bo_reserved [qxl]] *ERROR* failed to allocate VRAM BO
[  457.271770] qxl 0000:00:02.0: object_init failed for (16388096, 0x00000001)
[  457.271783] [drm:qxl_alloc_bo_reserved [qxl]] *ERROR* failed to allocate VRAM BO
[  472.631701] qxl 0000:00:02.0: object_init failed for (5246976, 0x00000001)
[  472.631713] [drm:qxl_alloc_bo_reserved [qxl]] *ERROR* failed to allocate VRAM BO
[  626.231759] qxl 0000:00:02.0: object_init failed for (16388096, 0x00000001)
[  626.231772] [drm:qxl_alloc_bo_reserved [qxl]] *ERROR* failed to allocate VRAM BO
[  641.591647] qxl 0000:00:02.0: object_init failed for (16388096, 0x00000001)
[  641.591658] [drm:qxl_alloc_bo_reserved [qxl]] *ERROR* failed to allocate VRAM BO
[  663.608036] qxl 0000:00:02.0: object_init failed for (6074368, 0x00000001)
[  663.608055] [drm:qxl_alloc_bo_reserved [qxl]] *ERROR* failed to allocate VRAM BO
[  718.903682] qxl 0000:00:02.0: object_init failed for (16388096, 0x00000001)
[  718.903695] [drm:qxl_alloc_bo_reserved [qxl]] *ERROR* failed to allocate VRAM BO
[  719.045773] input: spice vdagent tablet as /devices/virtual/input/input7
[  732.688590] input: spice vdagent tablet as /devices/virtual/input/input8
```