### PR TITLE
feat: add a vixos cp command

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
             packages = with pkgs; [
               python39Packages.libvirt
               python39Packages.pycryptodome
+              python39Packages.paramiko
               ((import ./virt-viewer-without-menu) pkgs)
             ];
           };


### PR DESCRIPTION
I keep making ugly commits, but I believe it's better to have something working now and refactor later than to try to create ideal code from the start.

This PR implements a `cp` commants with (almost) all possible combinations

```
[vixos]$ python3 -m vixos cp firefox:/etc/passwd alacritty:/home/user/kot
[vixos]$ python3 -m vixos cp firefox:/etc/passwd /tmp/test
[vixos]$ python3 -m vixos cp /tmp/test alacritty:/home/user/kot
[vixos]$ python3 -m vixos cp /tmp/test /tmp/test1
Just use `cp`...
[vixos]$
```