### PR TITLE
feat: add a mount command

### DIFF
--- a/docs/design-doc-command-line.md
+++ b/docs/design-doc-command-line.md
@@ -1,0 +1,25 @@
+# Design doc: Command Line
+
+### Overview
+
+We need to plan and implement a proper command line interface for the tool.
+Ideally we will pick something that is familiar for the users, and at the
+same time easy to use and fits the project scope.
+
+### Design
+
+I propose that we stay consistent with docker and kubectl as much as possible -
+they may serve a different purpose, but many of the parameters will overlap.
+
+The docker-inspired commands we will initially implement:
+
+- [ ] `vixos build` - create a new profile (or `vixos create`?)
+- [ ] `vixos run` - start a new VM (based on a existing profile) 
+- [ ] `vixos stop` - stop a running VM
+- [ ] `vixos ps` - list running VMs
+- [ ] `vixos cp` - copy files between a VM and a local filesystem
+- [ ] `vixos attach` - get a shell in the running VM
+
+Other commands:
+
+- [ ] `vixos mount` - mount the current directory to the same path in the VM

--- a/vixos/__main__.py
+++ b/vixos/__main__.py
@@ -98,7 +98,7 @@ class AppVM:
             ]
         )
 
-        with open("result/bin/run-nixos-vm", "r") as configf:
+        with open(f"result/bin/run-{self.name}-vm", "r") as configf:
             config = configf.read()
 
         reginfo = re.findall("regInfo=.*/registration", config)[0]
@@ -106,7 +106,8 @@ class AppVM:
         realpath = os.readlink("result/system")
         os.unlink("result")
 
-        qcow2 = f"{self.vixos_path}/empty_rootfs.qcow2"
+        # TODO: find a way to share the rootfs more cleanly
+        qcow2 = f"{self.vixos_path}/{self.name}.qcow2"
         if not Path(qcow2).exists():
             subprocess.check_call(["qemu-img", "create", "-f", "qcow2", qcow2, "40M"])
 

--- a/vixos/template_nix.py
+++ b/vixos/template_nix.py
@@ -42,12 +42,15 @@ in {
   environment.systemPackages = [ appRunner pkgs.%s ];
 
   services.xserver.displayManager.sessionCommands = "${appRunner}/bin/app &";
+
+  networking.hostName = "%s";
 }
 """ % (
         package,
         executable,
         pubkey,
         pubkey,
+        package,
         package,
     )
 

--- a/vixos/template_nix.py
+++ b/vixos/template_nix.py
@@ -62,6 +62,18 @@ def generate_base_nix():
 
 base_nix = """{pkgs, ...}:
 {
+  systemd.services.home-user-build-xmonad = {
+    description = "Link xmonad configuration";
+    serviceConfig = {
+      ExecStart = "/bin/sh -c 'mkdir -p /home/user/.xmonad && ln -sf /etc/xmonad.hs /home/user/.xmonad/xmonad.hs && /run/current-system/sw/bin/xmonad --recompile'";
+      RemainAfterExit = "yes";
+      User = "user";
+      Restart = "on-failure";
+      TimeoutSec = 10;
+    };
+    wantedBy = [ "multi-user.target" ];
+  };
+
   services.xserver = {
     enable = true;
     desktopManager.xterm.enable = false;

--- a/vixos/template_xml.py
+++ b/vixos/template_xml.py
@@ -97,7 +97,7 @@ xml_template = """
       <source dir='{shared_path}'/>
       <target dir='shared'/> <!-- workaround for nixpkgs/nixos/modules/virtualisation/qemu-vm.nix -->
     </filesystem>
-    <filesystem type='mount' accessmode='mapped'>
+    <filesystem type='mount' accessmode='passthrough'>
       <source dir='{shared_path}'/>
       <target dir='home'/>
     </filesystem>
@@ -109,11 +109,22 @@ xml_template = """
 </domain>
 """
 
+
+def generate_mount_xml(
+    source: str,
+    tag: str,
+) -> str:
+    return mount_xml_template.format(
+        source_dir=source,
+        mount_tag=tag,
+    )
+
+
 mount_xml_template = """
 <filesystem type='mount' accessmode='passthrough'>
   <binary path='/run/current-system/sw/bin/virtiofsd' xattr='on' />
   <driver type='virtiofs' queue='1024'/>
-  <source dir='/home/msm/Projects/ctf'/>
-  <target dir='ctf'/>
+  <source dir='{source_dir}'/>
+  <target dir='{mount_tag}'/>
 </filesystem>
 """

--- a/vixos/template_xml.py
+++ b/vixos/template_xml.py
@@ -108,3 +108,12 @@ xml_template = """
   </devices>
 </domain>
 """
+
+mount_xml_template = """
+<filesystem type='mount' accessmode='passthrough'>
+  <binary path='/run/current-system/sw/bin/virtiofsd' xattr='on' />
+  <driver type='virtiofs' queue='1024'/>
+  <source dir='/home/msm/Projects/ctf'/>
+  <target dir='ctf'/>
+</filesystem>
+"""


### PR DESCRIPTION
```
❯ nix develop                                                                                                                                                                                 python39Packages.black
-[vixos]$ python3 -m vixos mount --help
usage: __main__.py mount [-h] package [source] [destination]

positional arguments:
  package      Profile (package) name.
  source       Source directory (on the host). Uses current workign directory by default.
  destination  Destination directory (in the VM). Same as source directory by default.

optional arguments:
  -h, --help   show this help message and exit
```

...and some random refactorings too. Sorry.