### PR TITLE
fix: revert paramiko ssh

### DIFF
--- a/vixos/ssh.py
+++ b/vixos/ssh.py
@@ -1,11 +1,4 @@
-import os
 from pathlib import Path
-import select
-import signal
-import socket
-import sys
-import termios
-import tty
 from Crypto.PublicKey import RSA
 import subprocess
 import paramiko
@@ -30,44 +23,20 @@ class SshManager:
         return self.privkey.publickey().exportKey("OpenSSH").decode()
 
     def interactive_session(self, user: str, host: str) -> None:
-        ssh = self.ssh_session(user, host)
-        width, height = os.get_terminal_size()
-        shell_chan = ssh.invoke_shell(os.getenv('TERM', 'vt100'), width, height)
-
-        def signal_handler(_signum, _frame):
-            width, height = os.get_terminal_size()
-            shell_chan.resize_pty(width, height)
-        signal.signal(signal.SIGWINCH, signal_handler)
-
-        tty_attr = termios.tcgetattr(sys.stdin)
-        try:
-            # make terminal raw, disable line buffering
-            tty.setraw(sys.stdin.fileno())
-            tty.setcbreak(sys.stdin.fileno())
-            shell_chan.settimeout(0.0)
-
-            while True:
-                read_ready, _, _ = select.select([shell_chan, sys.stdin], [], [])
-                if shell_chan in read_ready:
-                    try:
-                        b = shell_chan.recv(1024)
-                        if len(b) == 0:
-                            print(f'\nConnection to {host} closed')
-                            break
-                        sys.stdout.buffer.write(b)
-                        sys.stdout.flush()
-                    except socket.timeout:
-                        pass
-                if sys.stdin in read_ready:
-                    b = sys.stdin.buffer.read(1)
-                    if len(b) == 0:
-                        break
-                    shell_chan.send(b)
-        finally:
-            # restore saved tty attributes
-            termios.tcsetattr(sys.stdin, termios.TCSADRAIN, tty_attr)
-            # reset temporary signal handler back to SIG_DFL (default)
-            signal.signal(signal.SIGWINCH, signal.SIG_DFL)
+        # TODO: use a hardcoded known host key here instead?
+        # TODO: use paramiko session instead of shelling to ssh?
+        subprocess.check_call(
+            [
+                "ssh",
+                f"user@{host}",
+                "-i",
+                str(self.privkey_path),
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+            ]
+        )
 
     def ssh_session(self, user: str, host: str) -> paramiko.SSHClient:
         ssh = paramiko.SSHClient()


### PR DESCRIPTION
Sadly looks like we can't excape from shelling out to ssh binary (at least not witout a large effort).